### PR TITLE
Use clang++ from prebuilts instead of host g++

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CFLAGS := -I . -lpthread -Wall -Wpedantic -Wextra
-CC := g++
+CC := clang++
 
 MANAGER_SRCS := vInputManager.cpp vInputDevice.cpp
 


### PR DESCRIPTION
This is required to enable setup path restrictions
for Android 11

Tracked-On: OAM-95316
Signed-off-by: yaravapa <yasoda.aravapalli@intel.com>