### PR TITLE
Fix clang compiler issue

### DIFF
--- a/vInputDevice.cpp
+++ b/vInputDevice.cpp
@@ -269,9 +269,10 @@ int vInputDevice::getMsgQ()
     return mqId;
 }
 
-static void sendKeyThread(vInputDevice *vD)
+static void sendKeyThread(vInputDevice *vDev)
 {
     struct mQData data = {};
+    vInputDevice *vD = vDev;
     int mqId = vD->getMsgQ();
 
     while (true) {


### PR DESCRIPTION
After msgrcv blocking call, first argument of the
function is getting modified. This problem happens
only with clang compiler. So used a local variable
to store the value of function argument.

Tracked-On: OAM-96707
Signed-off-by: Nemallapudi Jaikrishna <nemallapudi.jaikrishna@intel.com>