### PR TITLE
[DO NOT MERGE] Make the input resolution initialized as horizontal mode by default

### DIFF
--- a/lgInputDevice.cpp
+++ b/lgInputDevice.cpp
@@ -364,8 +364,8 @@ int lgInputDevice::createInputDevice(uint16_t keyCode, bool gvtdMode)
     dev.id.product = 0x1;
     dev.id.version = 1;
 
-    signed int touch_xres = 600;
-    signed int touch_yres = 960;
+    signed int touch_xres = 960;
+    signed int touch_yres = 600;
 
     /* single touch inputs */
     dev.absmax[ABS_MT_SLOT] = 0;


### PR DESCRIPTION
This is to adapt most user friendly input resolution.

Signed-off-by: Wan Shuang <shuang.wan@intel.com>
Tracked-On: OAM-101264