### PR TITLE
Fix for Kylin Hang Issue

### DIFF
--- a/lgInputDevice.cpp
+++ b/lgInputDevice.cpp
@@ -385,8 +385,8 @@ int lgInputDevice::createInputDevice(uint16_t keyCode, bool gvtdMode)
     dev.absmin[ABS_PRESSURE] = 0;
     dev.absmax[ABS_PRESSURE] = 0xff;
 
-    dev.absmin[ABS_MT_TOUCH_MAJOR] = 0;
-    dev.absmax[ABS_MT_TOUCH_MAJOR] = 0xff;
+    // dev.absmin[ABS_MT_TOUCH_MAJOR] = 0;
+    // dev.absmax[ABS_MT_TOUCH_MAJOR] = 0xff;
 
     dev.absmin[ABS_MT_PRESSURE] = 0;
     dev.absmax[ABS_MT_PRESSURE] = 0xff;


### PR DESCRIPTION
Fix to to avoid the kylin machine hang
after CIV launch.

Tracked-On: OAM-102227
Signed-off-by: Vilas R K <vilas.r.k@intel.com>