### PR TITLE
Fix compilation error in sendKey.cpp

### DIFF
--- a/sendKey.cpp
+++ b/sendKey.cpp
@@ -16,6 +16,7 @@
  */
 
 #include <string.h>
+#include <stdint.h>
 #include <iostream>
 
 #include "sendKey.h"


### PR DESCRIPTION
Compile error "unknown type name 'uint32_t'" since stdint.h is not included.

Tracked-On: OAM-113237