### PR TITLE
Fix Static Analysis Issues for VInput Manager Module.

### DIFF
--- a/lgInputDevice.cpp
+++ b/lgInputDevice.cpp
@@ -42,6 +42,8 @@ lgInputDevice::lgInputDevice()
     mqId = 0;
     virt = false;
     sourceDev.count = 0;
+    mouseType = 0;
+    fd[MAX_DEV - 1] = {0};
 }
 
 void lgInputDevice::setVirtMode(bool mode)
@@ -280,7 +282,8 @@ int lgInputDevice::getMsgQ()
     struct input_event ev = {};
     int n = 1;
     while (n > 0) {
-        n = msgrcv(mqId, &ev, sizeof(struct input_event), 1, IPC_NOWAIT);
+	/*The msgsz argument contains the size of the message in bytes, excluding the length of the message type (4 byte long).*/
+        n = msgrcv(mqId, &ev, sizeof(struct input_event) - sizeof(long), 1, IPC_NOWAIT);
     }
 
     return mqId;
@@ -292,12 +295,18 @@ static void sendKeyThread(lgInputDevice *vDev)
     lgInputDevice *vD = vDev;
     vD->type = MOUSE;
     int mqId = vD->getMsgQ();
+
+    if (mqId < 0) {
+        cout << "Failed to get msgq id" << endl;
+        return ;
+    }
+
     while (true) {
-            if (msgrcv(mqId, &mD, sizeof(struct mQData1), 1, 0) < 0) {
-                printf("error no: %s mousetype %d\n", strerror(errno), vD->mouseType);
-                continue;
-	    }
-	    vD->sendEvent(mD.ev.type, mD.ev.code, mD.ev.value);
+        if (msgrcv(mqId, &mD, sizeof(struct mQData1) - sizeof(long), 1, 0) < 0) {
+            printf("error no: %s mousetype %d\n", strerror(errno), vD->mouseType);
+            continue;
+	}
+	vD->sendEvent(mD.ev.type, mD.ev.code, mD.ev.value);
     }
 }
 

--- a/sendKey.cpp
+++ b/sendKey.cpp
@@ -62,7 +62,7 @@ static void sendPowerEvent(int32_t ctrl)
         exit(0);
 
     buf.bCtrl = static_cast<uint32_t>(ctrl);
-    msgsnd(mqId, &buf, sizeof(buf), 0);
+    msgsnd(mqId, &buf, sizeof(buf) - sizeof(long), 0);
 }
 
 static void sendVolumeEvent(int32_t ctrl)
@@ -76,11 +76,11 @@ static void sendVolumeEvent(int32_t ctrl)
     switch (ctrl) {
     case UP:
         buf.bCtrl = UP;
-        msgsnd(mqId, &buf, sizeof(buf), 0);
+        msgsnd(mqId, &buf, sizeof(buf) - sizeof(long), 0);
         break;
     case DOWN:
         buf.bCtrl = DOWN;
-        msgsnd(mqId, &buf, sizeof(buf), 0);
+        msgsnd(mqId, &buf, sizeof(buf) - sizeof(long), 0);
         break;
     default:
         cout << "Invalid Volume control option" << endl;

--- a/vInputDevice.cpp
+++ b/vInputDevice.cpp
@@ -263,7 +263,7 @@ int vInputDevice::getMsgQ()
     struct mQData data = {};
     int n = 1;
     while (n > 0) {
-        n = msgrcv(mqId, &data, sizeof(struct mQData), 1, IPC_NOWAIT);
+        n = msgrcv(mqId, &data, sizeof(struct mQData) - sizeof(long), 1, IPC_NOWAIT);
     }
 
     return mqId;
@@ -275,8 +275,13 @@ static void sendKeyThread(vInputDevice *vDev)
     vInputDevice *vD = vDev;
     int mqId = vD->getMsgQ();
 
+    if (mqId < 0) {
+            cout << "Failed to get msgq id" << endl;
+            return ;
+    }
+
     while (true) {
-        msgrcv(mqId, &data, sizeof(struct mQData), 1, 0);
+        msgrcv(mqId, &data, sizeof(struct mQData) - sizeof(long), 1, 0);
         if (vD->type == VOLUME) {
             switch (data.bCtrl) {
             case UP:


### PR DESCRIPTION
Below mentioned Static Analysis Issues will be solved. +-------------------------------------+
| Argument cannot be negative         |
| Uninitialized scalar field          |
| Out-of-bounds access                |
| Uninitialized scalar variable       |
+-------------------------------------+

SYSTEM CALL: msgsnd();

int msgsnd(int msgid, const void *msgp, size_t msgsz, int msgflg);

The msgsz argument contains the size of the message in bytes, excluding the length of the message type (4 byte long).

SYSTEM CALL: msgrcv();

int msgrcv(int msgid, void *msgp, size_t msgsz, long int msgtyp, int msgflg);

The msgsz argument contains the size of the message in bytes, excluding the length of the message type (4 byte long).

Tracked-On: OAM-114634