### PR TITLE
Fix uint32_t building issue on Ubuntu24.04

### DIFF
--- a/sendKey.cpp
+++ b/sendKey.cpp
@@ -16,6 +16,7 @@
  */
 
 #include <string.h>
+#include <stdint.h>
 #include <iostream>
 
 #include "sendKey.h"


### PR DESCRIPTION
Issue Detailed: vinput-manager building failed on Ubuntu24.04 and reports unknown type name 'uint32_t' in sendKey.cpp.

Issue Fixed: include stdint.h in sendKey.cpp.

Tested-On: Passed image building on Ubuntu24.04.

Tracked-On: OAM-126210