### PR TITLE
explicit add the cstdint header for clang compile

### DIFF
--- a/sendKey.cpp
+++ b/sendKey.cpp
@@ -17,6 +17,7 @@
 
 #include <string.h>
 #include <iostream>
+#include <cstdint>
 
 #include "sendKey.h"
 


### PR DESCRIPTION
fix the build errors with the clang15 and onward:
clang++ sendKey.cpp -I . -lpthread -Wall -Wpedantic -Wextra -o sendkey sendKey.cpp:64:29: error: unknown type name 'uint32_t'
   64 |     buf.bCtrl = static_cast<uint32_t>(ctrl);
         |                             ^


Tracked-On: OAM-129122